### PR TITLE
Replace escalation e-mail list

### DIFF
--- a/docs/ug/src/main/jbake/content/rules.adoc
+++ b/docs/ug/src/main/jbake/content/rules.adoc
@@ -370,7 +370,7 @@ A consensus that a test produces invalid results will result in the exclusion of
 When a`challenge` issue is rejected, it must be closed with a label of `invalid` to indicate it has been rejected.
 There appeal process for challenges rejected on technical terms is outlined in Escalation Appeal.
 If, however, an implementer feels the TCK challenge process was not followed, an appeal issue should be filed with specification project’s TCK issue tracker using the label `challenge-appeal`.
-A project lead should escalate the issue with the Jakarta EE Specification Committee via email (jakarta.ee-spec.committee@eclipse.org).
+A project lead should escalate the issue with the Jakarta EE Specification Committee via email (jakarta.ee-spec@eclipse.org).
 The committee will evaluate the matter purely in terms of due process.
 If the appeal is accepted, the original TCK challenge issue will be reopened and a label of `appealed-challenge` added, along with a discussion of the appeal decision, and the `challenge-appeal` issue with be closed.
 If the appeal is rejected, the `challenge-appeal` issue should closed with a label of `invalid`.


### PR DESCRIPTION
Substitute public Spec. e-mail list for escalations jakarta.ee-spec@eclipse.org