### PR TITLE
update scripts to use docker image with jdk17.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ spec:
     - "james.local"
   containers:
   - name: mail-tck-ci
-    image: jakartaee/cts-javamail-base:0.2
+    image: jakartaee/cts-javamail-base:0.3
     command:
     - cat
     tty: true
@@ -71,8 +71,8 @@ spec:
            description: 'URL required for downloading GlassFish Full/Web profile bundle' )
     choice(name: 'RUNTIME', choices: 'Glassfish\nANGUS',
            description: 'Run JAF Tests with Angus/Glassfish' )
-    choice(name: 'JDK', choices: 'JDK11',
-           description: 'Java SE Version to be used for running TCK either JDK11' )
+    choice(name: 'JDK', choices: 'JDK11\nJDK17',
+           description: 'Java SE Version to be used for running TCK either JDK11 or JDK17' )
     choice(name: 'LICENSE', choices: 'EPL\nEFTL',
            description: 'License file to be used to build the TCK bundle(s) either EPL(default) or Eclipse Foundation TCK License' )
   }

--- a/docker/build_mailtck.sh
+++ b/docker/build_mailtck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 #
-# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,7 +15,6 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
-export JAVA_HOME=${JDK11_HOME}
 export PATH=$JAVA_HOME/bin:$PATH
 
 echo "ANT_HOME=$ANT_HOME"

--- a/docker/run_mailtck.sh
+++ b/docker/run_mailtck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 #
-# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,8 +21,6 @@ else
   echo "[ERROR] TCK bundle not found"
   exit 1
 fi
-
-export JAVA_HOME=${JDK11_HOME}
 
 if [[ "$JDK" == "JDK12" || "$JDK" == "jdk12" ]];then
   export JAVA_HOME=${JDK12_HOME}

--- a/tests/api/SignatureTest.html
+++ b/tests/api/SignatureTest.html
@@ -2,7 +2,7 @@
 <head>
 <!--
 
-    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,31 +42,33 @@ It also verifies the existence and correct modifiers of public fields.
 		-TestURL $testURL
 		-Package jakarta.mail
 		-FileName jakarta.mail_2.1.sig
-		-exclude java.util.Map
-	    -exclude java.lang.Object
-	    -exclude java.io.ByteArrayInputStream
-	    -exclude java.io.InputStream
-	    -exclude java.lang.Deprecated
-	    -exclude java.io.Writer
-	    -exclude java.io.OutputStream
-	    -exclude java.util.List
-	    -exclude java.util.Collection
-	    -exclude java.lang.instrument.IllegalClassFormatException
-	    -exclude javax.transaction.xa.XAException
-	    -exclude javax.xml.transform.sax
-	    -exclude java.lang.annotation.Repeatable
-	    -exclude java.lang.InterruptedException
-	    -exclude java.lang.CloneNotSupportedException
-	    -exclude java.lang.Throwable
-	    -exclude java.lang.Thread
-	    -exclude java.lang.Enum
-	    -exclude org.xml.sax
+		-IgnoreJDKClass java.util.Map
+	    -IgnoreJDKClass java.lang.Object
+	    -IgnoreJDKClass java.io.ByteArrayInputStream
+	    -IgnoreJDKClass java.io.InputStream
+	    -IgnoreJDKClass java.lang.Deprecated
+	    -IgnoreJDKClass java.io.Writer
+	    -IgnoreJDKClass java.io.OutputStream
+	    -IgnoreJDKClass java.util.List
+	    -IgnoreJDKClass java.util.Collection
+	    -IgnoreJDKClass java.lang.instrument.IllegalClassFormatException
+	    -IgnoreJDKClass javax.transaction.xa.XAException
+	    -IgnoreJDKClass javax.xml.transform.sax
+	    -IgnoreJDKClass java.lang.annotation.Repeatable
+	    -IgnoreJDKClass java.lang.InterruptedException
+	    -IgnoreJDKClass java.lang.CloneNotSupportedException
+	    -IgnoreJDKClass java.lang.Throwable
+	    -IgnoreJDKClass java.lang.Thread
+	    -IgnoreJDKClass java.lang.Enum
+	    -IgnoreJDKClass org.xml.sax
+	    -IgnoreJDKClass java.lang.Enum.EnumDesc
+	    -IgnoreJDKClass java.lang.constant.Constable
 	<TR><TD><B>keywords</B> <TD>extensionAPI
 </TABLE>
 
 <hr>
-<EM>Last Updated: 20/10/2021<BR>
-&copy; Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+<EM>Last Updated: 18/01/2022<BR>
+&copy; Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
 ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.</EM>
 </body>
 </html>


### PR DESCRIPTION
update scripts to use docker image with jdk17.
CI run JDK 11- https://ci.eclipse.org/jakartaee-tck/job/guru/job/mail-tck-guru/job/master/15/
CI run JDK 17 - https://ci.eclipse.org/jakartaee-tck/job/guru/job/mail-tck-guru/job/master/14/
Signed-off-by: gurunandan.rao@oracle.com <gurunandan.rao@oracle.com>